### PR TITLE
Add multi-dex dump support

### DIFF
--- a/android/oat2dex.sh
+++ b/android/oat2dex.sh
@@ -7,18 +7,24 @@ if [ -z "${OAT}" ]; then
 	echo "Usage: $0 <file.oat>"
 	exit 0
 fi
-HIT=$(r2 -n -q -c '/ dex\n035' "${OAT}" 2>/dev/null |grep hit0_0 |awk '{print $1}')
-if [ -z "${HIT}" ]; then
-	echo "[-] ERROR: Can't find dex header"
+HITS=( $(r2 -n -q -c '/ dex\n035' "${OAT}" 2>/dev/null |grep hit |awk '{print $1}') )
+if [ ${#HITS[@]} -eq 0 ]; then
+	echo "[-] ERROR: Can't find dex headers"
 	exit 1
+elif [ ${#HITS[@]} -eq 1 ]; then
+	echo "[+] DEX header found at address: ${HITS[0]}"
 else
-	echo "[+] DEX header found at address: ${HIT}"
+	echo "[+] Multiple DEX headers found at addresses:"
+	for addr in ${HITS[@]}; do echo "  $addr"; done
 fi
-SIZE=$(r2 -n -q -c "pf i @${HIT}+32 ~[2]" "${OAT}" 2>/dev/null)
-echo "[+] Dex file size: ${SIZE} bytes"
-r2 -q -c "pr ${SIZE} @${HIT} > ${OAT}.dex" "${OAT}" 2>/dev/null
-if [ $? -eq 0 ]; then
-	echo "[+] Dex file dumped to: ${OAT}.dex"
-else
-	echo "[-] ERROR: Something went wrong :("
-fi
+
+for DEX_ADDR in ${HITS[@]}; do
+	SIZE=$(r2 -n -q -c "pf i @${DEX_ADDR}+32 ~[2]" "${OAT}" 2>/dev/null)
+	echo "[+] Dex file size: ${SIZE} bytes"
+	r2 -q -c "pr ${SIZE} @${DEX_ADDR} > ${OAT}.${DEX_ADDR}.dex" "${OAT}" 2>/dev/null
+	if [ $? -eq 0 ]; then
+		echo "[+] Dex file dumped to: ${OAT}.${DEX_ADDR}.dex"
+	else
+		echo "[-] ERROR: Something went wrong :("
+	fi
+done


### PR DESCRIPTION
Thought you find that useful.

With a little more crafting you can extract the original filenames as well from OAT. :)

anestisb@deephole:[AndroScriptoVault]: ./oat2dex.sh system@framework@boot.oat 
[+] Multiple DEX headers found at addresses:
  0x0000e3bc
  0x002cc5b4
  0x0030d5f8
  0x00351ed4
  0x00357e64
  0x004587ac
  0x005a028c
  0x00e0c138
  0x00f71f34
  0x0108f234
  0x010b47ac
  0x010d1500
  0x01109f20
  0x01412db8
  0x0153db8c
[+] Dex file size: 2875896 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x0000e3bc.dex
[+] Dex file size: 266308 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x002cc5b4.dex
[+] Dex file size: 280796 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x0030d5f8.dex
[+] Dex file size: 24464 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x00351ed4.dex
[+] Dex file size: 1050952 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x00357e64.dex
[+] Dex file size: 1342176 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x004587ac.dex
[+] Dex file size: 8830636 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x005a028c.dex
[+] Dex file size: 1465852 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x00e0c138.dex
[+] Dex file size: 1168128 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x00f71f34.dex
[+] Dex file size: 152952 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x0108f234.dex
[+] Dex file size: 118100 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x010b47ac.dex
[+] Dex file size: 231968 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x010d1500.dex
[+] Dex file size: 3182232 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x01109f20.dex
[+] Dex file size: 1224148 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x01412db8.dex
[+] Dex file size: 737152 bytes
[+] Dex file dumped to: system@framework@boot.oat.0x0153db8c.dex
